### PR TITLE
feat(frontend): gestionar carga y visualización de datasets maestros

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import HomePage from "./features/home/pages/HomePage"
 import PredictionsPage from "./features/predictions/pages/PredictionsPage"
 import ResultsPage from "./features/results/pages/ResultsPage"
 import ReportPage from "./features/reports/pages/ReportPage"
+import MasterDatasetsPage from "./features/masters/pages/MasterDatasetsPage"
 
 function App() {
 
@@ -30,6 +31,7 @@ function App() {
                   <Route path="/results" element={<ResultsPage />} />
                   <Route path="/results/:jobId" element={<ResultsPage />} />
                   <Route path="/reports/" element={<ReportPage />} />
+                  <Route path="/masters" element={<MasterDatasetsPage />} />
 
                   {/* Ruta 404 */}
                   <Route path="*" element={

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -6,6 +6,8 @@ import {
     LineChart,
     Settings,
     FileSpreadsheet,
+    Database,
+    UploadCloud,
 } from "lucide-react"
 import { cn } from "../../lib/utils"
 
@@ -13,8 +15,9 @@ import { cn } from "../../lib/utils"
 const navItems = [
     { name: "Inicio", href: "/", icon: LayoutDashboard },
     { name: "Generar Prediccion", href: "/forecast", icon: TrendingUp },
-    { name: "Predicciones", href: "/predictions", icon: LineChart },
     { name: "Resultados", href: "/results", icon: FilePieChart },
+    { name: "Predicciones", href: "/predictions", icon: LineChart },
+    { name: "Datasets Maestro", href: "/masters", icon: Database },
     { name: "Reportes", href: "/reports", icon: FileSpreadsheet },
 ]
 

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -7,17 +7,16 @@ import {
     Settings,
     FileSpreadsheet,
     Database,
-    UploadCloud,
 } from "lucide-react"
 import { cn } from "../../lib/utils"
 
 // Definimos la estructua de los items de navegacion para que el componente sea mantenible
 const navItems = [
     { name: "Inicio", href: "/", icon: LayoutDashboard },
-    { name: "Generar Prediccion", href: "/forecast", icon: TrendingUp },
-    { name: "Resultados", href: "/results", icon: FilePieChart },
-    { name: "Predicciones", href: "/predictions", icon: LineChart },
     { name: "Datasets Maestro", href: "/masters", icon: Database },
+    { name: "Generar Prediccion", href: "/forecast", icon: TrendingUp },
+    { name: "Predicciones", href: "/predictions", icon: LineChart },
+    { name: "Resultados", href: "/results", icon: FilePieChart },
     { name: "Reportes", href: "/reports", icon: FileSpreadsheet },
 ]
 

--- a/src/features/masters/components/MasterUploadCard.tsx
+++ b/src/features/masters/components/MasterUploadCard.tsx
@@ -199,9 +199,9 @@ export function MasterUploadCard({ entityType, title, description }: MasterUploa
 
             {/* Banner de estado fijo abajo (solo success) - Replica exacta del screenshot */}
             {status === "success" && (
-                <div className="bg-blue-50 dark:bg-blue-950/30 border-t border-blue-100 dark:border-blue-900/50 p-2 flex items-start gap-2 text-xs">
-                    <CheckCircle2 className="h-4 w-4 text-blue-600 dark:text-blue-400 flex-shrink-0 mt-0.5" />
-                    <span className="text-blue-700 dark:text-blue-300 font-medium">
+                <div className="bg-blue-50 dark:bg-blue-950/30 border-t border-blue-100 dark:border-blue-900/50 p-4 flex items-center gap-3">
+                    <CheckCircle2 className="h-5 w-5 text-blue-600 dark:text-blue-400 flex-shrink-0" />
+                    <span className="text-blue-700 dark:text-blue-300 font-medium text-sm">
                         {resultMessage}
                     </span>
                 </div>

--- a/src/features/masters/components/MasterUploadCard.tsx
+++ b/src/features/masters/components/MasterUploadCard.tsx
@@ -11,11 +11,13 @@ interface MasterUploadCardProps {
     entityType: MasterEntityType;
     title: string;
     description: string;
+    lastUpdated?: string | null;
+    onUploadSuccess?: () => void;
 }
 
 type UploadState = "idle" | "confirm" | "uploading" | "success" | "error";
 
-export function MasterUploadCard({ entityType, title, description }: MasterUploadCardProps) {
+export function MasterUploadCard({ entityType, title, description, lastUpdated, onUploadSuccess }: MasterUploadCardProps) {
 
     const [status, setStatus] = React.useState<UploadState>("idle");
     const [progress, setProgress] = React.useState(0);
@@ -57,6 +59,10 @@ export function MasterUploadCard({ entityType, title, description }: MasterUploa
             setResultMessage(`Dataset cargado: ${selectedFile.name} (${response.processed_count.toLocaleString()} filas)`);
             setStatus("success");
 
+            if (onUploadSuccess) {
+                onUploadSuccess();
+            }
+
             // Auto-reset después de 5 segundos? No, mejor dejarlo visible.
 
         } catch (error) {
@@ -87,6 +93,22 @@ export function MasterUploadCard({ entityType, title, description }: MasterUploa
         setResultMessage("");
     };
 
+    // Formatear fecha
+    const formattedDate = React.useMemo(() => {
+        if (!lastUpdated) return null;
+        try {
+            return new Date(lastUpdated).toLocaleString('es-ES', {
+                day: '2-digit',
+                month: '2-digit',
+                year: 'numeric',
+                hour: '2-digit',
+                minute: '2-digit'
+            });
+        } catch (e) {
+            return null;
+        }
+    }, [lastUpdated]);
+
     return (
         <div
             className={cn(
@@ -96,9 +118,16 @@ export function MasterUploadCard({ entityType, title, description }: MasterUploa
         >
             {/* Header del Card */}
             <div className="p-4 space-y-1 border-b bg-muted/20">
-                <h3 className="font-semibold tracking-tight text-base flex items-center gap-2">
-                    {title}
-                </h3>
+                <div className="flex justify-between items-start">
+                    <h3 className="font-semibold tracking-tight text-base flex items-center gap-2">
+                        {title}
+                    </h3>
+                    {formattedDate && (
+                        <span className="text-[10px] bg-muted px-2 py-0.5 rounded-full text-muted-foreground whitespace-nowrap">
+                            Act: {formattedDate}
+                        </span>
+                    )}
+                </div>
                 <p className="text-sm text-muted-foreground line-clamp-2">
                     {description}
                 </p>

--- a/src/features/masters/components/MasterUploadCard.tsx
+++ b/src/features/masters/components/MasterUploadCard.tsx
@@ -1,0 +1,211 @@
+import * as React from "react"
+import { useDropzone } from "react-dropzone"
+import { Upload, Loader2, FileText, CheckCircle2, XCircle, AlertTriangle } from "lucide-react"
+import { cn } from "../../../lib/utils"
+import { Button } from "../../../components/ui/button"
+import { logger } from "../../../services/logger"
+import { masterService, type MasterEntityType } from "../../../services/api"
+import { getErrorInfo, handleError } from "../../../lib/errors"
+
+interface MasterUploadCardProps {
+    entityType: MasterEntityType;
+    title: string;
+    description: string;
+}
+
+type UploadState = "idle" | "confirm" | "uploading" | "success" | "error";
+
+export function MasterUploadCard({ entityType, title, description }: MasterUploadCardProps) {
+
+    const [status, setStatus] = React.useState<UploadState>("idle");
+    const [progress, setProgress] = React.useState(0);
+    const [selectedFile, setSelectedFile] = React.useState<File | null>(null);
+    const [resultMessage, setResultMessage] = React.useState<string>("");
+
+    // Configuración de Dropzone
+    const { getRootProps, getInputProps, isDragActive } = useDropzone({
+        accept: {
+            'text/csv': ['.csv'],
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': ['.xlsx']
+        },
+        maxFiles: 1,
+        disabled: status === "uploading",
+        onDrop: (acceptedFiles) => {
+            const file = acceptedFiles[0];
+            if (file) {
+                setSelectedFile(file);
+                setStatus("confirm");
+                logger.debug("UI", `Archivo seleccionado para ${entityType}`, { fileName: file.name });
+            }
+        }
+    });
+
+    /**
+     * Confirma y ejecuta la carga
+     */
+    const handleConfirmUpload = async () => {
+        if (!selectedFile) return;
+
+        setStatus("uploading");
+        setProgress(0);
+
+        try {
+            const response = await masterService.uploadMasterData(selectedFile, entityType, (pct) => {
+                setProgress(pct);
+            });
+
+            setResultMessage(`Dataset cargado: ${selectedFile.name} (${response.processed_count.toLocaleString()} filas)`);
+            setStatus("success");
+
+            // Auto-reset después de 5 segundos? No, mejor dejarlo visible.
+
+        } catch (error) {
+            const appError = handleError(error, "UI", `Upload master ${entityType}`);
+            const info = getErrorInfo(appError);
+            setResultMessage(info.message);
+            setStatus("error");
+        }
+    };
+
+    /**
+     * Cancela la selección
+     */
+    const handleCancel = (e: React.MouseEvent) => {
+        e.stopPropagation(); // Evitar abrir el dropzone de nuevo
+        setSelectedFile(null);
+        setStatus("idle");
+        setResultMessage("");
+    };
+
+    /**
+     * Resetea el componente solo si está en error o success
+     */
+    const handleReset = (e: React.MouseEvent) => {
+        e.stopPropagation();
+        setSelectedFile(null);
+        setStatus("idle");
+        setResultMessage("");
+    };
+
+    return (
+        <div
+            className={cn(
+                "group relative border rounded-xl overflow-hidden bg-card text-card-foreground shadow-sm transition-all h-full flex flex-col",
+                status === "idle" && "hover:border-primary/50 hover:shadow-md"
+            )}
+        >
+            {/* Header del Card */}
+            <div className="p-4 space-y-1 border-b bg-muted/20">
+                <h3 className="font-semibold tracking-tight text-base flex items-center gap-2">
+                    {title}
+                </h3>
+                <p className="text-sm text-muted-foreground line-clamp-2">
+                    {description}
+                </p>
+            </div>
+
+            {/* Cuerpo del Card - Area Interactiva */}
+            <div className="flex-1 p-4 relative min-h-[160px] flex flex-col justify-center">
+
+                {/* 1. ESTADO: IDLE (Dropzone) */}
+                {status === "idle" && (
+                    <div
+                        {...getRootProps()}
+                        className={cn(
+                            "absolute inset-0 m-2 border-2 border-dashed rounded-lg flex flex-col items-center justify-center text-center cursor-pointer transition-colors",
+                            isDragActive ? "border-primary bg-primary/5" : "border-muted-foreground/20 hover:border-primary/50 hover:bg-muted/30"
+                        )}
+                    >
+                        <input {...getInputProps()} />
+                        <Upload className={cn("h-8 w-8 mb-2 transition-colors", isDragActive ? "text-primary" : "text-muted-foreground")} />
+                        <p className="text-sm font-medium">Arrastra tu CSV aquí</p>
+                        <p className="text-xs text-muted-foreground mt-1">o haz clic para buscar</p>
+                    </div>
+                )}
+
+                {/* 2. ESTADO: CONFIRMACION */}
+                {status === "confirm" && selectedFile && (
+                    <div className="flex flex-col items-center justify-center space-y-4 animate-in fade-in zoom-in-95 duration-200">
+                        <div className="flex items-center gap-2 text-sm font-medium bg-muted px-3 py-1.5 rounded-full max-w-full">
+                            <FileText className="h-4 w-4" />
+                            <span className="truncate max-w-[180px]">{selectedFile.name}</span>
+                        </div>
+
+                        <div className="bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-900/50 p-3 rounded-md text-center">
+                            <AlertTriangle className="h-5 w-5 text-amber-600 dark:text-amber-500 mx-auto mb-1" />
+                            <p className="text-xs text-amber-800 dark:text-amber-200 font-medium">
+                                Esto reemplazará todos los datos existentes.
+                            </p>
+                        </div>
+
+                        <div className="flex gap-2 w-full">
+                            <Button size="sm" variant="ghost" className="flex-1" onClick={handleCancel}>
+                                Cancelar
+                            </Button>
+                            <Button size="sm" className="flex-1" onClick={handleConfirmUpload}>
+                                Confirmar
+                            </Button>
+                        </div>
+                    </div>
+                )}
+
+                {/* 3. ESTADO: UPLOADING */}
+                {status === "uploading" && (
+                    <div className="flex flex-col items-center justify-center w-full space-y-4">
+                        <Loader2 className="h-8 w-8 text-primary animate-spin" />
+                        <div className="w-full space-y-1">
+                            <div className="flex justify-between text-xs text-muted-foreground">
+                                <span>Subiendo...</span>
+                                <span>{progress}%</span>
+                            </div>
+                            <div className="h-2 w-full bg-secondary rounded-full overflow-hidden">
+                                <div
+                                    className="h-full bg-primary transition-all duration-300 ease-out"
+                                    style={{ width: `${progress}%` }}
+                                />
+                            </div>
+                        </div>
+                    </div>
+                )}
+
+                {/* 4. ESTADO: SUCCESS o ERROR */}
+                {(status === "success" || status === "error") && (
+                    <div className="flex flex-col items-center justify-center text-center space-y-3 animate-in fade-in">
+                        {status === "success" ? (
+                            <div className="h-10 w-10 bg-green-100 dark:bg-green-900/30 text-green-600 dark:text-green-400 rounded-full flex items-center justify-center">
+                                <CheckCircle2 className="h-6 w-6" />
+                            </div>
+                        ) : (
+                            <div className="h-10 w-10 bg-red-100 dark:bg-red-900/30 text-red-600 dark:text-red-400 rounded-full flex items-center justify-center">
+                                <XCircle className="h-6 w-6" />
+                            </div>
+                        )}
+
+                        <div className="space-y-1">
+                            <p className={cn("text-sm font-medium", status === "success" ? "text-green-700 dark:text-green-300" : "text-red-700 dark:text-red-300")}>
+                                {status === "success" ? "Carga Exitosa" : "Error en la carga"}
+                            </p>
+                            <p className="text-xs text-muted-foreground break-words max-w-[200px] mx-auto">
+                                {resultMessage}
+                            </p>
+                        </div>
+
+                        <Button size="sm" variant="outline" onClick={handleReset} className="h-8 text-xs">
+                            {status === "success" ? "Cargar otro" : "Intentar de nuevo"}
+                        </Button>
+                    </div>
+                )}
+            </div>
+
+            {/* Banner de estado fijo abajo (solo success) - Replica exacta del screenshot */}
+            {status === "success" && (
+                <div className="bg-blue-50 dark:bg-blue-950/30 border-t border-blue-100 dark:border-blue-900/50 p-2 flex items-start gap-2 text-xs">
+                    <CheckCircle2 className="h-4 w-4 text-blue-600 dark:text-blue-400 flex-shrink-0 mt-0.5" />
+                    <span className="text-blue-700 dark:text-blue-300 font-medium">
+                        {resultMessage}
+                    </span>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/features/masters/pages/MasterDatasetsPage.tsx
+++ b/src/features/masters/pages/MasterDatasetsPage.tsx
@@ -48,7 +48,7 @@ export default function MasterDatasetsPage() {
             {/* GRID DE CARDS */}
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                 {MASTER_ENTITIES.map((entity) => (
-                    <div key={entity.type} className="h-64">
+                    <div key={entity.type} className="h-96">
                         <MasterUploadCard
                             entityType={entity.type}
                             title={entity.title}

--- a/src/features/masters/pages/MasterDatasetsPage.tsx
+++ b/src/features/masters/pages/MasterDatasetsPage.tsx
@@ -1,5 +1,7 @@
 import { MasterUploadCard } from "../components/MasterUploadCard";
-import { type MasterEntityType } from "../../../services/api";
+import { masterService, type MasterEntityType, type MasterStatusResponse } from "../../../services/api";
+import { useEffect, useState } from "react";
+import { logger } from "../../../services/logger";
 
 const MASTER_ENTITIES: { type: MasterEntityType; title: string; description: string }[] = [
     {
@@ -35,6 +37,22 @@ const MASTER_ENTITIES: { type: MasterEntityType; title: string; description: str
 ];
 
 export default function MasterDatasetsPage() {
+
+    const [statuses, setStatuses] = useState<MasterStatusResponse | null>(null);
+
+    const fetchStatus = async () => {
+        try {
+            const data = await masterService.getMasterStatus();
+            setStatuses(data);
+        } catch (error) {
+            logger.error("UI", "Error fetching master status", error);
+        }
+    };
+
+    useEffect(() => {
+        fetchStatus();
+    }, []);
+
     return (
         <div className="space-y-6 animate-in fade-in duration-500">
             {/* ENCABEZADO */}
@@ -53,6 +71,8 @@ export default function MasterDatasetsPage() {
                             entityType={entity.type}
                             title={entity.title}
                             description={entity.description}
+                            lastUpdated={statuses?.[entity.type]}
+                            onUploadSuccess={fetchStatus}
                         />
                     </div>
                 ))}

--- a/src/features/masters/pages/MasterDatasetsPage.tsx
+++ b/src/features/masters/pages/MasterDatasetsPage.tsx
@@ -1,0 +1,62 @@
+import { MasterUploadCard } from "../components/MasterUploadCard";
+import { type MasterEntityType } from "../../../services/api";
+
+const MASTER_ENTITIES: { type: MasterEntityType; title: string; description: string }[] = [
+    {
+        type: "products",
+        title: "Productos",
+        description: "Catálogo maestro de productos (SKUs, Marcas, Categorias)."
+    },
+    {
+        type: "territories",
+        title: "Territorios",
+        description: "Estructura geográfica de ventas (Regiones, Zonas, Territorios)."
+    },
+    {
+        type: "warehouses",
+        title: "Almacenes",
+        description: "Centros de distribución y puntos de despacho."
+    },
+    {
+        type: "channels",
+        title: "Canales",
+        description: "Canales de venta y segmentación de clientes."
+    },
+    {
+        type: "accounts",
+        title: "Cuentas",
+        description: "Clientes y cuentas clave (Key Accounts)."
+    },
+    {
+        type: "distributors",
+        title: "Distribuidores",
+        description: "Socios comerciales y red de distribución externa."
+    }
+];
+
+export default function MasterDatasetsPage() {
+    return (
+        <div className="space-y-6 animate-in fade-in duration-500">
+            {/* ENCABEZADO */}
+            <div className="flex flex-col gap-1">
+                <h1 className="text-3xl font-bold tracking-tight">Datasets Maestro</h1>
+                <p className="text-muted-foreground">
+                    Gestiona los datos de referencia para el enriquecimiento de reportes y filtros.
+                </p>
+            </div>
+
+            {/* GRID DE CARDS */}
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                {MASTER_ENTITIES.map((entity) => (
+                    <div key={entity.type} className="h-64">
+                        <MasterUploadCard
+                            entityType={entity.type}
+                            title={entity.title}
+                            description={entity.description}
+                        />
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/src/services/api/index.ts
+++ b/src/services/api/index.ts
@@ -34,5 +34,6 @@ export type {
 
 export type {
     MasterEntityType,
-    MasterUploadResponse
+    MasterUploadResponse,
+    MasterStatusResponse
 } from "./masterService"

--- a/src/services/api/index.ts
+++ b/src/services/api/index.ts
@@ -7,6 +7,10 @@
  */
 
 export { forecastService } from "./forecastService"
+export { reportService } from "./reportService"
+export { seriesService } from "./seriesService"
+export { masterService } from "./masterService"
+
 export type {
     UploadResponse,
     ForecastStartResponse,
@@ -18,4 +22,17 @@ export type {
     ForecastHorizon,
     TimeUnit,
     HistoricalDataPoint,
+    ForecastConfiguration,
+    BackendFileResponse,
+    ReportResponse,
+    ReportRow,
+    JobSummary,
+    JobsListResponse,
+    PredictionFilterParams,
+    ForecastPredictionResponse
 } from "./types"
+
+export type {
+    MasterEntityType,
+    MasterUploadResponse
+} from "./masterService"

--- a/src/services/api/masterService.ts
+++ b/src/services/api/masterService.ts
@@ -1,0 +1,72 @@
+/**
+ * Servicio para la gestión de datos maestros
+ * Endpoint: POST /api/v1/masters/{entity_type}/upload
+ */
+import axios from "axios";
+import { logger } from "../logger";
+import { handleError } from "../../lib/errors";
+import { API } from "../../config/constants";
+
+export type MasterEntityType =
+    | "products"
+    | "channels"
+    | "accounts"
+    | "territories"
+    | "warehouses"
+    | "distributors";
+
+export interface MasterUploadResponse {
+    message: string;
+    processed_count: number;
+}
+
+export const masterService = {
+
+    /**
+     * Sube un archivo CSV de datos maestros
+     * 
+     * @param file Archivo CSV a subir
+     * @param entityType Tipo de entidad maestra
+     * @param onProgress Callback opcional para progeso (0-100)
+     */
+    uploadMasterData: async (
+        file: File,
+        entityType: MasterEntityType,
+        onProgress?: (progress: number) => void
+    ): Promise<MasterUploadResponse> => {
+        try {
+            logger.info("API", `Iniciando carga maestra para ${entityType}`, {
+                fileName: file.name,
+                size: file.size
+            });
+
+            const formData = new FormData();
+            formData.append("file", file);
+
+            const url = `${API.BASE_URL}/masters/${entityType}/upload`;
+
+            const response = await axios.post<MasterUploadResponse>(
+                url,
+                formData,
+                {
+                    headers: { "Content-Type": "multipart/form-data" },
+                    onUploadProgress: (progressEvent) => {
+                        if (onProgress && progressEvent.total) {
+                            const percent = Math.round((progressEvent.loaded * 100) / progressEvent.total);
+                            onProgress(percent);
+                        }
+                    }
+                }
+            );
+
+            logger.info("API", `Carga maestra completada para ${entityType}`, {
+                processed: response.data.processed_count
+            });
+
+            return response.data;
+
+        } catch (error) {
+            throw handleError(error, "API", `Upload master ${entityType}`);
+        }
+    }
+};

--- a/src/services/api/masterService.ts
+++ b/src/services/api/masterService.ts
@@ -43,7 +43,7 @@ export const masterService = {
             const formData = new FormData();
             formData.append("file", file);
 
-            const url = `${API.BASE_URL}/masters/${entityType}/upload`;
+            const url = `${API.BASE_URL}/master/${entityType}/upload`;
 
             const response = await axios.post<MasterUploadResponse>(
                 url,

--- a/src/services/api/masterService.ts
+++ b/src/services/api/masterService.ts
@@ -20,6 +20,8 @@ export interface MasterUploadResponse {
     processed_count: number;
 }
 
+export type MasterStatusResponse = Record<MasterEntityType, string | null>;
+
 export const masterService = {
 
     /**
@@ -67,6 +69,18 @@ export const masterService = {
 
         } catch (error) {
             throw handleError(error, "API", `Upload master ${entityType}`);
+        }
+    },
+
+    /**
+     * Obtiene el estado de actualización de los maestros
+     */
+    getMasterStatus: async (): Promise<MasterStatusResponse> => {
+        try {
+            const response = await axios.get<MasterStatusResponse>(`${API.BASE_URL}/master/status`);
+            return response.data;
+        } catch (error) {
+            throw handleError(error, "API", "Get master status");
         }
     }
 };


### PR DESCRIPTION
Este PR introduce el módulo completo para la gestión de Datasets Maestros en el Frontend. Permite cargar archivos para actualizar datos de referencia (Productos, Territorios, etc.) y visualizar el estado de la última actualización.
### Características Implementadas
#### 1. Nueva Arquitectura de Página (`MasterDatasetsPage`)
*   Se creó una nueva ruta `/masters` y su item de navegación "Database" en el Sidebar.
*   Diseño en Grid Responsive para las 6 entidades maestras.
*   Gestión de estado centralizada para coordinar cargas y refrescar timestamps.

#### 2. Componente de Carga (`MasterUploadCard`)
*   **Drag & Drop**: Soporte para archivos `.csv` y `.xlsx`.
*   **Confirmación**: Modal inline que solicita confirmación antes de la carga.
*   **Feedback**: Indicadores de progreso (Barra de carga) y validación de tipos.
*   **Estado**: Muestra dinámicamente el mensaje "Act: [Fecha]" con la última actualización.
*   **Reactividad**: El timestamp se actualiza inmediatamente al finalizar la carga exitosa, invocando el refresh de la página padre.
**3. Integración API (`masterService`)**
*   Implementación de `uploadMasterData` y `getMasterStatus`
*   Definición de tipos (`MasterEntityType`, `MasterStatusResponse`)